### PR TITLE
Fixed size when polling length of FRAM to reflect actual size

### DIFF
--- a/adafruit_fram.py
+++ b/adafruit_fram.py
@@ -174,8 +174,7 @@ class FRAM:
                                  " list, or tuple.")
             if key >= self._max_size:
                 raise ValueError("Requested register '{0}' greater than maximum"
-                                 " FRAM register. ({1})".format(key,
-                                                            self._max_size - 1))
+                                 " FRAM register. ({1})".format(key, self._max_size - 1))
 
             self._write(key, value, self._wraparound)
 

--- a/adafruit_fram.py
+++ b/adafruit_fram.py
@@ -134,7 +134,7 @@ class FRAM:
                 fram[0:9]
         """
         if isinstance(address, int):
-            if not (0 < address < self._max_size):
+            if not 0 < address < self._max_size:
                 raise ValueError("Address '{0}' out of range. It must be 0 <= address < {1}."
                                  .format(address, self._max_size))
             buffer = bytearray(1)
@@ -143,15 +143,15 @@ class FRAM:
             if address.step is not None:
                 raise ValueError("Slice stepping is not currently available.")
 
-            registers = list(range(address.start if address.start is not None else 0,
-                                   address.stop + 1 if address.stop is not None else self._max_size))
-            if registers[0] < 0 or (registers[0] + len(registers)) > self._max_size:
+            regs = list(range(address.start if address.start is not None else 0,
+                              address.stop + 1 if address.stop is not None else self._max_size))
+            if regs[0] < 0 or (regs[0] + len(regs)) > self._max_size:
                 raise ValueError("Address slice out of range. It must be 0 <= [starting address"
-                                 ":stopping address] < {1}."
-                                 .format(address, self._max_size))
+                                 ":stopping address] < {0}."
+                                 .format(self._max_size))
 
-            buffer = bytearray(len(registers))
-            read_buffer = self._read_register(registers[0], buffer)
+            buffer = bytearray(len(regs))
+            read_buffer = self._read_register(regs[0], buffer)
 
         return read_buffer
 
@@ -173,7 +173,7 @@ class FRAM:
             if not isinstance(value, (int, bytearray, list, tuple)):
                 raise ValueError("Data must be a single integer, or a bytearray,"
                                  " list, or tuple.")
-            if not (0 < address < self._max_size):
+            if not 0 < address < self._max_size:
                 raise ValueError("Address '{0}' out of range. It must be 0 <= address < {1}."
                                  .format(address, self._max_size))
 

--- a/adafruit_fram.py
+++ b/adafruit_fram.py
@@ -317,7 +317,7 @@ class FRAM_SPI(FRAM):
             spi.readinto(read_buffer)
         return read_buffer
 
-    def _write(self, start_addressr, data, wraparound=False):
+    def _write(self, start_address, data, wraparound=False):
         buffer = bytearray(3)
         if not isinstance(data, int):
             data_length = len(data)

--- a/adafruit_fram.py
+++ b/adafruit_fram.py
@@ -106,7 +106,7 @@ class FRAM:
         return self._wp if self._wp_pin is None else self._wp_pin.value
 
     def __len__(self):
-        """ The maximum size of the current FRAM chip. This is the highest
+        """ The size of the current FRAM chip. This is one more than the highest
             register location that can be read or written to.
 
             .. code-block:: python
@@ -119,7 +119,7 @@ class FRAM:
                 # can be used with range
                 for i in range(0, len(fram))
         """
-        return self._max_size
+        return self._max_size + 1
 
 
     def __getitem__(self, key):

--- a/adafruit_fram.py
+++ b/adafruit_fram.py
@@ -134,7 +134,7 @@ class FRAM:
                 fram[0:9]
         """
         if isinstance(address, int):
-            if not 0 < address < self._max_size:
+            if not 0 <= address < self._max_size:
                 raise ValueError("Address '{0}' out of range. It must be 0 <= address < {1}."
                                  .format(address, self._max_size))
             buffer = bytearray(1)
@@ -173,7 +173,7 @@ class FRAM:
             if not isinstance(value, (int, bytearray, list, tuple)):
                 raise ValueError("Data must be a single integer, or a bytearray,"
                                  " list, or tuple.")
-            if not 0 < address < self._max_size:
+            if not 0 <= address < self._max_size:
                 raise ValueError("Address '{0}' out of range. It must be 0 <= address < {1}."
                                  .format(address, self._max_size))
 

--- a/adafruit_fram.py
+++ b/adafruit_fram.py
@@ -134,7 +134,7 @@ class FRAM:
                 fram[0:9]
         """
         if isinstance(key, int):
-            if key > self._max_size - 1:
+            if key >= self._max_size:
                 raise ValueError("Register '{0}' greater than maximum FRAM register."
                                  " ({1})".format(key, self._max_size - 1))
             buffer = bytearray(1)
@@ -172,7 +172,7 @@ class FRAM:
             if not isinstance(value, (int, bytearray, list, tuple)):
                 raise ValueError("Data must be a single integer, or a bytearray,"
                                  " list, or tuple.")
-            if key > self._max_size - 1:
+            if key >= self._max_size:
                 raise ValueError("Requested register '{0}' greater than maximum"
                                  " FRAM register. ({1})".format(key,
                                                             self._max_size - 1))


### PR DESCRIPTION
Addressing https://github.com/adafruit/Adafruit_CircuitPython_FRAM/issues/6

I also updated examples, comments, and error messages to reflect the change.