### PR TITLE
Move consts out of class level

### DIFF
--- a/adafruit_fram.py
+++ b/adafruit_fram.py
@@ -68,6 +68,7 @@ _SPI_OPCODE_READ = const(0x3)  # Read memory code
 _SPI_OPCODE_WRITE = const(0x2)  # Write memory code
 _SPI_OPCODE_RDID = const(0x9F)  # Read device ID
 
+
 class FRAM:
     """
     Driver base for the FRAM Breakout.

--- a/adafruit_fram.py
+++ b/adafruit_fram.py
@@ -60,6 +60,13 @@ _I2C_PROD_ID = const(0x510)
 _SPI_MANF_ID = const(0x04)
 _SPI_PROD_ID = const(0x302)
 
+_SPI_OPCODE_WREN = const(0x6)  # Set write enable latch
+_SPI_OPCODE_WRDI = const(0x4)  # Reset write enable latch
+_SPI_OPCODE_RDSR = const(0x5)  # Read status register
+_SPI_OPCODE_WRSR = const(0x1)  # Write status register
+_SPI_OPCODE_READ = const(0x3)  # Read memory code
+_SPI_OPCODE_WRITE = const(0x2)  # Write memory code
+_SPI_OPCODE_RDID = const(0x9F)  # Read device ID
 
 class FRAM:
     """
@@ -282,12 +289,6 @@ class FRAM_I2C(FRAM):
             self._wp_pin.value = value
 
 
-# the following pylint disables are related to the '_SPI_OPCODE' consts, the super
-# class setter '@FRAM.write_protected.setter', and pylint not being able to see
-# 'spi.write()' in SPIDevice. Travis run for reference:
-# https://travis-ci.com/sommersoft/Adafruit_CircuitPython_FRAM/builds/87112669
-
-# pylint: disable=no-member,undefined-variable
 class FRAM_SPI(FRAM):
     """ SPI class for FRAM.
 
@@ -300,14 +301,6 @@ class FRAM_SPI(FRAM):
     :param int baudrate: SPI baudrate to use. Default is ``1000000``.
     :param int max_size: Size of FRAM in Bytes. Default is ``8192``.
     """
-
-    _SPI_OPCODE_WREN = const(0x6)  # Set write enable latch
-    _SPI_OPCODE_WRDI = const(0x4)  # Reset write enable latch
-    _SPI_OPCODE_RDSR = const(0x5)  # Read status register
-    _SPI_OPCODE_WRSR = const(0x1)  # Write status register
-    _SPI_OPCODE_READ = const(0x3)  # Read memory code
-    _SPI_OPCODE_WRITE = const(0x2)  # Write memory code
-    _SPI_OPCODE_RDID = const(0x9F)  # Read device ID
 
     # pylint: disable=too-many-arguments,too-many-locals
     def __init__(


### PR DESCRIPTION
Fix for #12 

The combination of the use of MicroPython's `const()` along with naming the variable with a leading `_` was leading to incompatibility with non-native CP boards when used at the class level. This PR simply moves the consts to the module level.

Tested on Itsy:
```python
Adafruit CircuitPython 5.3.1 on 2020-07-13; Adafruit ItsyBitsy M0 Express with samd21g18
>>> import board
>>> import busio
>>> import digitalio
>>> import adafruit_fram
>>> spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
>>> cs = digitalio.DigitalInOut(board.D5)
>>> fram = adafruit_fram.FRAM_SPI(spi, cs)
>>> fram[0] = 1
>>> print(fram[0])
bytearray(b'\x01')
>>>
```

and RPI:
```python
pi@raspberrypi:~/blinka/lib/python3.7/site-packages $ python3
Python 3.7.3 (default, Dec 20 2019, 18:57:59) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import board
>>> import busio
>>> import digitalio
>>> import adafruit_fram
>>> spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
>>> cs = digitalio.DigitalInOut(board.D5)
>>> fram = adafruit_fram.FRAM_SPI(spi, cs)
>>> fram[0] = 1
>>> print(fram[0])
bytearray(b'\x01')
>>>
```
