### PR TITLE
Allow bytes as well

### DIFF
--- a/adafruit_fram.py
+++ b/adafruit_fram.py
@@ -169,9 +169,9 @@ class FRAM:
             raise RuntimeError("FRAM currently write protected.")
 
         if isinstance(address, int):
-            if not isinstance(value, (int, bytearray, list, tuple)):
+            if not isinstance(value, (int, bytes, bytearray, list, tuple)):
                 raise ValueError(
-                    "Data must be a single integer, or a bytearray," " list, or tuple."
+                    "Data must be a single integer, bytes, bytearray, list, or tuple."
                 )
             if not 0 <= address < self._max_size:
                 raise ValueError(


### PR DESCRIPTION
For #24. Using `bytes` was essentially already supported. Just needed to let the driver know how cool it was.

```python
Adafruit CircuitPython 6.1.0 on 2021-01-21; Adafruit QT Py M0 with samd21e18
>>> import board
>>> import adafruit_fram
>>> fram = adafruit_fram.FRAM_I2C(board.I2C())
>>> message = b'Python is fun!'
>>> fram[0] = message
>>> fram[0:len(message)-1]
bytearray(b'Python is fun!')
>>> 
```